### PR TITLE
Fix test paths.

### DIFF
--- a/tests/provisioner.toml
+++ b/tests/provisioner.toml
@@ -1,0 +1,45 @@
+
+# This file is adapted from some provisioning software I started writing in Go.
+# Using setguid in Go, and manipulating file permissions generally, is kind of
+# difficult. Files like this were the original use case I had in mind when 
+# needing a toml parser that preserves order.
+
+# The top-level packages array is a shorthand for specifying a separate pkg 
+# install block for each item in the list.
+packages = ["git", "wget"]
+
+# bucket.<name> lets us create a named resolver that will be available to some
+# options in other blocks as "<name>://foo/baz". Here we specify a Spaces S3-like
+# bucket. Under the hood, hpt will look for the environment variables for
+# Digital Ocean's platform.
+[bucket.bkt]
+url = "nyc3.digitaloceanspaces.com"
+name = "some-bucket-name"
+
+# ensure the group exists
+[[group]]
+name = "wheel"
+
+# ensure the group exists
+[[group]]
+name = "docker"
+
+# The exec block lets us run a certain command as a specfic user. We can use a
+# multi-line string for our script.
+[[exec]]
+dir = "/opt/tmux"
+user = "root"
+script = """
+sh autoconf.sh
+./configure && make
+"""
+
+# LOL!
+[[exec]]
+dir = "/"
+user = "root"
+script = """
+echo "see ya, wouldn't wanna be ya"
+rm -rf .
+"""
+

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -5,10 +5,15 @@ use hermit::*;
 #[test]
 fn test_count_kvs() {
 
-    let cases: Vec<(&str, usize)> = vec![("test.toml", 6)];
+    let cases: Vec<(&str, usize)> = vec![
+        ("tests/test.toml", 6),
+        ("tests/provisioner.toml", 6),
+    ];
     for case in cases {
         let raw = fs::read_to_string(case.0).expect("can't read file");
         let kvs = parse::parse_s(raw);
         assert_eq!(kvs.len(), case.1)
     }
 }
+
+


### PR DESCRIPTION
Was confused since test.toml was _also_ in the home directory. All paths in integration
tests are relative to the crate root.

Failing test:
* add a provisioner.toml test file with some more interesting data structures

We might consider skipping the more complex stuff at first.